### PR TITLE
Fixes for choc option

### DIFF
--- a/src/cljs/dactyl_generator/common.cljs
+++ b/src/cljs/dactyl_generator/common.cljs
@@ -25,11 +25,11 @@
 (defn keyswitch-height
   "the y dimension of an mx style keyswitch, in millimeter."
   [c]
-  (if (get c :configuration-ibnuda-edits?) 14.0 14.4))
+  (if (get c :configuration-ibnuda-edits?) (if (not= :choc (get c :configuration-switch-type)) 14.0 13.8) 14.4))
 (defn keyswitch-width
   "the x dimension of an mx style keyswitch, in millimeter."
   [c]
-  (if (get c :configuration-ibnuda-edits?) 14.0 14.4))
+  (if (get c :configuration-ibnuda-edits?) (if (not= :choc (get c :configuration-switch-type)) 14.0 13.8) 14.4))
 
 (defn keyswitch-width-c [c] (keyswitch-width c))
 

--- a/src/cljs/dactyl_generator/common.cljs
+++ b/src/cljs/dactyl_generator/common.cljs
@@ -270,8 +270,8 @@
                                                      (/ (plate-thickness c) 2)]))
                               :choc (->> (cube (+ (keyswitch-width-c c) 3) holder-thickness (* (plate-thickness c) 0.65))
                                          (translate [0
-                                                     (+ holder-thickness (/ (keyswitch-height c) 2))
-                                                     (* (plate-thickness c) 0.7)]))
+                                                     (+ (/ holder-thickness 2) (/ (keyswitch-height c) 2))
+                                                     ( + (/ (plate-thickness c) 2) (/ (- (plate-thickness c) (* (plate-thickness c) 0.65)) 2))]))
                               (->> (cube (+ (keyswitch-width-c c) mx-margin) holder-thickness (plate-thickness c))
                                    (translate [0
                                                (+ (/ holder-thickness 2) (/ (keyswitch-height c) 2))
@@ -286,10 +286,10 @@
                                                             0
                                                             (- (plate-thickness c)
                                                                (/ alps-notch-height 2))])))
-                              :choc (->> (cube holder-thickness (+ (keyswitch-height c) 3.3) (* (plate-thickness c) 0.65))
+                              :choc (->> (cube holder-thickness (+ (keyswitch-height c) 3.3) 2.2) ;2.2 is the clamp-height of kailh choc V1 switches according to datasheet 
                                          (translate [(+ (/ holder-thickness 2) (/ (keyswitch-width-c c) 2))
                                                      0
-                                                     (* (plate-thickness c) 0.7)]))
+                                                     ( + (/ (plate-thickness c) 2) (/ (- (plate-thickness c) 2.2) 2))]))
                               (->> (cube holder-thickness (+ (keyswitch-height c) mx-margin) (plate-thickness c))
                                    (translate [(+ (/ holder-thickness 2) (/ (keyswitch-width-c c) 2))
                                                0


### PR DESCRIPTION
The experimental choc option had some issues with the keyholes that I have addressed.

- Keyholes have not been square due to an missing division by two in the keywall transformation.
- Keyholes had MX size, although chocs are a bit smaller. Chocs are now set to 13.8mm square
- Keyholes had an small heightoffset above the sourrounding plate, that has been fixed
- Keyholesidewallheight (left/right) has been changed to fixed size of 2.2mm to allow the clamps of choc keys to grip on that wall.

open issue; For the 1.5u thumb buttons, the keyhole should be rotated 90 degrees to allow the rotated mount of the button for usage of horizontal keycaps instead of harder to source vertical ones (At least as option).

Tested the changes with the FDM print of this Manuform:
#manuform:Ch4IBhAEGgNzaXgiBHplcm8qBGNob2MyBW91dGllOAAaCggAEgRub25lGAAiF1UAAABBGAAgAV0AAOBAZQAAQEBAAEgAMvkBlQMAACBAnQMAAAAAgAMBiAMBDc3MTL4VAAAAAB1mZsZAJQAAsMAtzcxEwTUAAGBAPWZm5j9FmpmZPk2amblAVQAAQMBdAACgQGUzM3nCbTMzEcJ1AADQwXjCA4ABvxaIAdgTlQEzMy/CnQEzM03CpQEAAMjBqAGqBrABixW4AYgOxQEAAETCzQEAAMzB1QEAAHDB2AHQBeABixXoAbgI9QEAAOjB/QEAACTChQIAAGDBiALGCpAClRCYAvYEpQIAAAzCrQIAAHDBtQIAAKDAuAKEB8ACyRHIAoQH1QIAAHjB3QIAAGDB5QIAACBA6AKEB/AClRD4AsIDKgYIABAAGAA=

Beside the too low Vertical (Y) Spacing setting used, the Kailh Choc switches fit perfectly.